### PR TITLE
Added the official Xcode 12.5 UUID

### DIFF
--- a/Leaf.ideplugin/Contents/Info.plist
+++ b/Leaf.ideplugin/Contents/Info.plist
@@ -24,6 +24,7 @@
 	</array>
 	<key>DVTPlugInCompatibilityUUIDs</key>
 	<array>
+		<string>F56A1938-53DE-493D-9D64-87EE6C415E4D</string>
 		<string>8A66E736-A720-4B3C-92F1-33D9962C69DF</string>
 		<string>65C57D32-1E9B-44B8-8C04-A27BA7AAE2C4</string>
 		<string>DA4FDFD8-C509-4D8B-8B55-84A7B66AE701</string>


### PR DESCRIPTION
Added the UUID for the official App Store release of Xcode 12.5 to the compatibility list.
